### PR TITLE
fixed tibble bug in UserConceptLookupFn

### DIFF
--- a/.Rhistory
+++ b/.Rhistory
@@ -1,0 +1,4 @@
+devtools::document()
+devtools::document()
+devtools::document()
+devtools::document()

--- a/R/LowLevelCreateFn.R
+++ b/R/LowLevelCreateFn.R
@@ -163,8 +163,7 @@ createConceptAttribute <- function(conceptIds,
                                   connection = connection,
                                   vocabularyDatabaseSchema = vocabularyDatabaseSchema,
                                   oracleTempSchema = oracleTempSchema,
-                                  mapToStandard = mapToStandard,
-                                  simplifyToDataframe = TRUE)
+                                  mapToStandard = mapToStandard)
   concepts$INVALID_REASON_CAPTION <- "Unknown"
   concepts$STANDARD_CONCEPT_CAPTION <- "Unknown"
   concepts <- concepts[,c(7,1,2,3,11,12,4)]

--- a/R/UserCommands.R
+++ b/R/UserCommands.R
@@ -55,9 +55,7 @@ loadComponent <- function(path){
 #' Function to read in a circe json
 #'
 #' This function reads a circe json an builds the cohort definition in an execution space
-#' @param connectionDetails   An object of type \code{connectionDetails} as created using the
-#'                            \code{\link[DatabaseConnector]{createConnectionDetails}} function in the
-#'                            DatabaseConnector package. Cannot be left NULL in this function.
+#' @template     Connection
 #' @template     VocabularyDatabaseSchema
 #' @template     OracleTempSchema
 #' @param jsonPath a path to the file we wish to import
@@ -71,6 +69,7 @@ loadComponent <- function(path){
 #' @export
 readInCirce <- function(jsonPath,
                         connectionDetails,
+                        connection = NULL,
                         vocabularyDatabaseSchema = NULL,
                         oracleTempSchema = NULL,
                         returnHash = FALSE){

--- a/R/UserConceptLookupFn.R
+++ b/R/UserConceptLookupFn.R
@@ -27,10 +27,6 @@
 #' @template     OracleTempSchema
 #' @param        conceptIds a vector of concept ids
 #' @param        mapToStandard logic to map to standard OMOP concept
-#' @param        simplifyToDataframe logic to return dataframe or tibble. If are piping this function
-#'               to create a concept set expression keep as true. Coercion to concept set expressions
-#'               requires the use of a dataframe. If false returns a tiblle where $. retrieves the
-#'               dataframe
 #' @return       a tibble data frame object with conceptId, conceptName, standardConcept,
 #'               standardConceptCaption, invalidReason, invalidReasonCaption, conceptCode,
 #'               domainId, vocabularyId, conceptClassId.
@@ -42,8 +38,7 @@ getConceptIdDetails <- function(conceptIds,
                                 connection = NULL,
                                 vocabularyDatabaseSchema = NULL,
                                 oracleTempSchema = NULL,
-                                mapToStandard = TRUE,
-                                simplifyToDataframe = TRUE) {
+                                mapToStandard = TRUE) {
 
   errorMessage <- checkmate::makeAssertCollection()
   checkmate::assertVector(conceptIds, add = errorMessage)
@@ -70,7 +65,8 @@ getConceptIdDetails <- function(conceptIds,
 
   #if mapping to the standard concept join to concept_relationship----------------------------------
   if (mapToStandard){
-    conceptIdToMap  <- conceptDetails$.$conceptId
+    #conceptIdToMap  <- conceptDetails$.$conceptId bug fix from dbConnector
+    conceptIdToMap  <- conceptDetails$conceptId
     mappingQuery <- "SELECT b.* FROM @vocabularyDatabaseSchema.concept_relationship a
     JOIN  @vocabularyDatabaseSchema.concept b on b.concept_id = a.concept_id_2 AND a.relationship_id = '@relationship'
     WHERE a.concept_id_1 in (@conceptId);"
@@ -82,9 +78,6 @@ getConceptIdDetails <- function(conceptIds,
                                                                  conceptId = conceptIdToMap,
                                                                  relationship = "Maps to") %>%
       dplyr::tibble()
-  }
-  if (simplifyToDataframe){
-    conceptDetails <- conceptDetails$.
   }
   return(conceptDetails)
 }
@@ -100,10 +93,6 @@ getConceptIdDetails <- function(conceptIds,
 #' @param        conceptCode a character vector of concept codes
 #' @param        vocabulary a single character string with the vocabulary of the codes
 #' @param        mapToStandard logic to map to standard OMOP concept
-#' @param        simplifyToDataframe logic to return dataframe or tibble. If are piping this function
-#'               to create a concept set expression keep as true. Coercion to concept set expressions
-#'               requires the use of a dataframe. If false returns a tiblle where $. retrieves the
-#'               dataframe
 #' @return       a tibble data frame object with conceptId, conceptName, standardConcept,
 #'               standardConceptCaption, invalidReason, invalidReasonCaption, conceptCode,
 #'               domainId, vocabularyId, conceptClassId.
@@ -116,8 +105,7 @@ getConceptCodeDetails <- function(conceptCode,
                                   connection = NULL,
                                   vocabularyDatabaseSchema = NULL,
                                   oracleTempSchema = NULL,
-                                  mapToStandard = TRUE,
-                                  simplifyToDataframe = TRUE) {
+                                  mapToStandard = TRUE) {
 
   errorMessage <- checkmate::makeAssertCollection()
   checkmate::assertVector(conceptCode, add = errorMessage)
@@ -146,7 +134,8 @@ getConceptCodeDetails <- function(conceptCode,
 
   #if mapping to the standard concept join to concept_relationship----------------------------------
   if (mapToStandard){
-    conceptIdToMap  <- conceptDetails$.$conceptId
+    #conceptIdToMap  <- conceptDetails$.$conceptId
+    conceptIdToMap  <- conceptDetails$conceptId
     mappingQuery <- "SELECT b.* FROM @vocabularyDatabaseSchema.concept_relationship a
     JOIN  @vocabularyDatabaseSchema.concept b on b.concept_id = a.concept_id_2 AND a.relationship_id = '@relationship'
     WHERE a.concept_id_1 in (@conceptId);"
@@ -160,9 +149,9 @@ getConceptCodeDetails <- function(conceptCode,
       dplyr::tibble()
   }
 
-  if (simplifyToDataframe){ #simplify to dataframe use for conceptsetexpressions
-    conceptDetails <- conceptDetails$.
-  }
+  # if (simplifyToDataframe){ #simplify to dataframe use for conceptsetexpressions
+  #   conceptDetails <- conceptDetails$.
+  # }
 
   return(conceptDetails)
 }
@@ -177,10 +166,6 @@ getConceptCodeDetails <- function(conceptCode,
 #' @template     OracleTempSchema
 #' @param        keyword a character string used to search OMOP concepts
 #' @param        searchType options to aid search. Can use like match, exact match or any match
-#' @param        simplifyToDataframe logic to return dataframe or tibble. If are piping this function
-#'               to create a concept set expression keep as true. Coercion to concept set expressions
-#'               requires the use of a dataframe. If false returns a tiblle where $. retrieves the
-#'               dataframe. For keyword lookup it is suggested to keep option false.
 #' @return       a tibble data frame object with conceptId, conceptName, standardConcept,
 #'               standardConceptCaption, invalidReason, invalidReasonCaption, conceptCode,
 #'               domainId, vocabularyId, conceptClassId.
@@ -192,8 +177,7 @@ lookupKeyword<-function(keyword,
                         connectionDetails = NULL,
                         connection = NULL,
                         vocabularyDatabaseSchema = NULL,
-                        oracleTempSchema = NULL,
-                        simplifyToDataframe = FALSE) {
+                        oracleTempSchema = NULL) {
 
   errorMessage <- checkmate::makeAssertCollection()
   checkmate::assertVector(keyword, add = errorMessage)
@@ -228,8 +212,5 @@ lookupKeyword<-function(keyword,
                                                                keyword = keyword) %>%
     dplyr::tibble()
 
-  if (simplifyToDataframe){ #simplify to dataframe use for conceptsetexpressions
-    conceptDetails <- conceptDetails$.
-  }
   return(conceptDetails)
 }

--- a/man/getConceptCodeDetails.Rd
+++ b/man/getConceptCodeDetails.Rd
@@ -11,8 +11,7 @@ getConceptCodeDetails(
   connection = NULL,
   vocabularyDatabaseSchema = NULL,
   oracleTempSchema = NULL,
-  mapToStandard = TRUE,
-  simplifyToDataframe = TRUE
+  mapToStandard = TRUE
 )
 }
 \arguments{
@@ -39,11 +38,6 @@ schema name, for example 'vocabulary.dbo'.}
 privileges for storing temporary tables.}
 
 \item{mapToStandard}{logic to map to standard OMOP concept}
-
-\item{simplifyToDataframe}{logic to return dataframe or tibble. If are piping this function
-to create a concept set expression keep as true. Coercion to concept set expressions
-requires the use of a dataframe. If false returns a tiblle where $. retrieves the
-dataframe}
 }
 \value{
 a tibble data frame object with conceptId, conceptName, standardConcept,

--- a/man/getConceptIdDetails.Rd
+++ b/man/getConceptIdDetails.Rd
@@ -10,8 +10,7 @@ getConceptIdDetails(
   connection = NULL,
   vocabularyDatabaseSchema = NULL,
   oracleTempSchema = NULL,
-  mapToStandard = TRUE,
-  simplifyToDataframe = TRUE
+  mapToStandard = TRUE
 )
 }
 \arguments{
@@ -36,11 +35,6 @@ schema name, for example 'vocabulary.dbo'.}
 privileges for storing temporary tables.}
 
 \item{mapToStandard}{logic to map to standard OMOP concept}
-
-\item{simplifyToDataframe}{logic to return dataframe or tibble. If are piping this function
-to create a concept set expression keep as true. Coercion to concept set expressions
-requires the use of a dataframe. If false returns a tiblle where $. retrieves the
-dataframe}
 }
 \value{
 a tibble data frame object with conceptId, conceptName, standardConcept,

--- a/man/lookupKeyword.Rd
+++ b/man/lookupKeyword.Rd
@@ -10,8 +10,7 @@ lookupKeyword(
   connectionDetails = NULL,
   connection = NULL,
   vocabularyDatabaseSchema = NULL,
-  oracleTempSchema = NULL,
-  simplifyToDataframe = FALSE
+  oracleTempSchema = NULL
 )
 }
 \arguments{
@@ -36,11 +35,6 @@ schema name, for example 'vocabulary.dbo'.}
 
 \item{oracleTempSchema}{Should be used in Oracle to specify a schema where the user has write
 privileges for storing temporary tables.}
-
-\item{simplifyToDataframe}{logic to return dataframe or tibble. If are piping this function
-to create a concept set expression keep as true. Coercion to concept set expressions
-requires the use of a dataframe. If false returns a tiblle where $. retrieves the
-dataframe. For keyword lookup it is suggested to keep option false.}
 }
 \value{
 a tibble data frame object with conceptId, conceptName, standardConcept,

--- a/man/readInCirce.Rd
+++ b/man/readInCirce.Rd
@@ -7,6 +7,7 @@
 readInCirce(
   jsonPath,
   connectionDetails,
+  connection = NULL,
   vocabularyDatabaseSchema = NULL,
   oracleTempSchema = NULL,
   returnHash = FALSE
@@ -17,7 +18,14 @@ readInCirce(
 
 \item{connectionDetails}{An object of type \code{connectionDetails} as created using the
 \code{\link[DatabaseConnector]{createConnectionDetails}} function in the
-DatabaseConnector package. Cannot be left NULL in this function.}
+DatabaseConnector package. Can be left NULL if \code{connection} is
+provided.}
+
+\item{connection}{An object of type \code{connection} as created using the
+\code{\link[DatabaseConnector]{connect}} function in the
+DatabaseConnector package. Can be left NULL if \code{connectionDetails}
+is provided, in which case a new connection will be opened at the start
+of the function, and closed when the function finishes.}
 
 \item{vocabularyDatabaseSchema}{Schema name where your OMOP vocabulary format resides.
 Note that for SQL Server, this should include both the database and
@@ -28,7 +36,6 @@ privileges for storing temporary tables.}
 
 \item{returnHash}{if true returns a has table with all components necessary to build the
 cohort definition including the cohort definition}
-
 }
 \value{
 returns the cohort definition


### PR DESCRIPTION
There was a bug that tables pulled from vocabulary table created a tibble with a "." layer. For example conceptTable$. was used to access the concept table pulled. The "." layer has been removed in updates of other packages. Therefore removed simplifyToDataframe option from concept lookup functions and removed "." reference within mapToStandard option. 