### PR TITLE
Update README with notes on model choice for agent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ is installed with the package, so it always matches the Capr version you have in
   compile its JSON to SQL.
 - `README.md` — per-agent setup instructions and design notes.
 
+**Requires a reasoning-capable, frontier-tier model.** In tools with automatic model selection
+(e.g., GitHub Copilot's "Auto"), explicitly pick a frontier model — Claude Sonnet/Opus-class,
+GPT-5-class, Gemini Pro-class or better — before invoking the skill. Lightweight "mini" /
+"flash" / non-reasoning tiers may produce cohort definitions that pass validation but are
+clinically wrong, and this is not fixable by refining the skill instructions.
+
 There are two ways to wire it up:
 
 **Copy the bundle into your project** (recommended — works with every agent, including ones

--- a/inst/llm/README.md
+++ b/inst/llm/README.md
@@ -18,6 +18,12 @@ loaded into your agent's context.
 - R with the Capr package installed (`remotes::install_github("OHDSI/Capr")`); CirceR comes with
   it.
 - The agent must be able to run `Rscript` (or you run the validation steps yourself).
+- **A reasoning-capable, frontier-tier model.** In tools with automatic model selection (e.g.,
+  GitHub Copilot's "Auto"), explicitly pick a frontier model — Claude Sonnet/Opus-class,
+  GPT-5-class, Gemini Pro-class or better — before invoking the skill. This is a setup choice
+  you make before the agent starts, not something the agent can fix for itself: model selection
+  happens above the agent loop, so text inside `SKILL.md` can't influence it. Lightweight
+  "mini" / "flash" / non-reasoning tiers may produce cohort definitions that pass `validate.R` but are clinically wrong — validation checks API usage, not clinical intent.
 
 If Capr is installed, this bundle is on disk at `system.file("llm", package = "Capr")`. 
 You have 2 options for accessing it with your agent:


### PR DESCRIPTION
I've been doing more testing, and performance of agent mode degrades on "auto" mode in GitHub Copilot, which sometimes chooses very light non-reasoning models. I chatted with Claude about this, and it said that the only way to get non-reasoning models to succeed in this sort of task is to make the workflow more rigid, with hard-coded tool calls and decision trees. At this time I think it's better/easier to just instruct users on which models they can and can't use. Models are going to keep getting better and cheaper so I'm not sure it's worth investing too much in the lowest common denominator.