### PR TITLE
Fix serialization error with named concept sets being passed in

### DIFF
--- a/R/cohort.R
+++ b/R/cohort.R
@@ -501,6 +501,8 @@ serializeCohortToJson <- function(object, ..., includeConceptSets = NULL) {
     # Restore original concept set ids in cohort structure (replaceCodesetId had assigned 0,1,2,...; map back to original ids).
     circe <- remapCirceCodesetIdsToOriginal(circe, guidTable)
   }
+  # Named lists causes a de-serialization error in circe-be
+  names(circe$ConceptSets) <- NULL
   as.character(jsonlite::toJSON(circe, auto_unbox = TRUE, ...))
 }
 


### PR DESCRIPTION
`jsonlite` will always try to serialize named list objects. There is no validation on what is passed in by the user so they can add illegal names without realizing silently causing badly formatted json output.

Trying to make a reproducible example as an issue but the problem, but its buried deeply in AI generated code.